### PR TITLE
Refactor: Centralize Rota State with RotaContext and Simplify Shift Management

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import localFont from "next/font/local";
 import Navbar from "@/ui/Navbar/Navbar"; // Import the Navbar component
 import "./globals.css";
 import { EmployeeProvider } from "@/lib/employees/context/EmployeeContext";
-
+import { RotaProvider } from "@/lib/rota/context/RotaContexts";
 const geistSans = localFont({
   src: "../fonts/GeistVF.woff",
   variable: "--font-geist-sans",
@@ -28,13 +28,15 @@ export default function RootLayout({
   return (
     <html lang="en">
       <EmployeeProvider>
-        <body
-          className={`${geistSans.variable} ${geistMono.variable} antialiased print:w-full min-h-screen mx-auto bg-gray-200 print:bg-transparent`}
-        >
-          <Navbar />
+        <RotaProvider>
+          <body
+            className={`${geistSans.variable} ${geistMono.variable} antialiased print:w-full min-h-screen mx-auto bg-gray-200 print:bg-transparent`}
+          >
+            <Navbar />
 
-          <main className="print:w-full w-[1560px] mx-auto">{children}</main>
-        </body>
+            <main className="print:w-full w-[1560px] mx-auto">{children}</main>
+          </body>
+        </RotaProvider>
       </EmployeeProvider>
     </html>
   );

--- a/src/lib/rota/context/RotaContexts.tsx
+++ b/src/lib/rota/context/RotaContexts.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React, { createContext, useContext, useCallback, useState } from "react";
+import { INITIAL_WEEK } from "../constants";
+import { DayShiftsMap, Shift, Week, Weekday } from "../rota";
+
+interface RotaContextType {
+  shifts: Week;
+  updateShiftsToWeekDay: (day: Weekday, dayShifts: DayShiftsMap) => void;
+  addShift: (day: Weekday, newShift: Shift) => void;
+  updateShift: (day: Weekday, shiftToUpdate: Shift) => void;
+  deleteShift: (day: Weekday, shiftId: string) => void;
+}
+
+const RotaContext = createContext<RotaContextType | undefined>(undefined);
+
+export const RotaProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [shifts, setShifts] = useState<Week>(INITIAL_WEEK);
+  const [assignmentStatus, setAssignmentStatus] = useState<
+    "modified" | "saved"
+  >("saved");
+
+  const updateShiftsToWeekDay = useCallback(
+    (day: Weekday, dayShifts: DayShiftsMap) => {
+      setShifts((prevShifts) => {
+        const updatedShifts = new Map(prevShifts);
+        updatedShifts.set(day, dayShifts);
+        return updatedShifts;
+      });
+      setAssignmentStatus("modified");
+    },
+    []
+  );
+
+  const addShift = (day: Weekday, newShift: Shift) => {
+    const newId = newShift.id || `${newShift.startTime}-${newShift.endTime}`;
+    const dayShifts = shifts.get(day);
+    const updatedDayShifts = new Map(dayShifts);
+    updatedDayShifts.set(newId, newShift);
+
+    const sortedEntries = Array.from(updatedDayShifts.entries()).sort(
+      ([, a], [, b]) => a.startTime.localeCompare(b.startTime)
+    );
+    const sortedDayShifts = new Map(sortedEntries);
+    updateShiftsToWeekDay(day, sortedDayShifts);
+  };
+
+  const updateShift = (day: Weekday, shiftToUpdate: Shift) => {
+    const newId =
+      shiftToUpdate.id || `${shiftToUpdate.startTime}-${shiftToUpdate.endTime}`;
+    const dayShifts = shifts.get(day);
+
+    const updatedDayShifts = new Map(dayShifts);
+    updatedDayShifts.delete(shiftToUpdate.id!);
+    updatedDayShifts.set(newId, shiftToUpdate);
+
+    const sortedEntries = Array.from(updatedDayShifts.entries()).sort(
+      ([, a], [, b]) => a.startTime.localeCompare(b.startTime)
+    );
+    const sortedDayShifts = new Map(sortedEntries);
+    updateShiftsToWeekDay(day, sortedDayShifts);
+  };
+
+  const deleteShift = (day: Weekday, shiftId: string) => {
+    const dayShifts = shifts.get(day);
+
+    const updatedDayShifts = new Map(dayShifts);
+    updatedDayShifts.delete(shiftId);
+    updateShiftsToWeekDay(day, updatedDayShifts);
+  };
+  return (
+    <RotaContext.Provider
+      value={{
+        updateShiftsToWeekDay,
+        shifts,
+        addShift,
+        updateShift,
+        deleteShift,
+      }}
+    >
+      {children}
+    </RotaContext.Provider>
+  );
+};
+
+export const useRotaContext = (): RotaContextType => {
+  const context = useContext(RotaContext);
+  if (!context) {
+    throw new Error(
+      "useEmployeeContext must be used within an EmployeeProvider"
+    );
+  }
+  return context;
+};

--- a/src/lib/rota/hooks/useOpeningTimes.ts
+++ b/src/lib/rota/hooks/useOpeningTimes.ts
@@ -1,0 +1,63 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect, useState } from "react";
+import { generateHoursArray } from "@/lib/rota/utils";
+import { Shift, Weekday, DayShiftsMap } from "@/lib/rota/rota";
+import { useRotaContext } from "@/lib/rota/context/RotaContexts";
+
+type UseOpeningTimesProps = {
+  day: Weekday;
+  dayShifts: DayShiftsMap;
+};
+
+export function useOpeningTimes({ day, dayShifts }: UseOpeningTimesProps) {
+  const [openingTimes, setOpeningTimes] = useState<string[]>([]);
+  const { updateShiftsToWeekDay } = useRotaContext(); // <- use it here
+
+  const handleOpeningTimeChange = (time: string, type: "open" | "close") => {
+    setOpeningTimes((prevTimes) => {
+      const newOpen = type === "open" ? time : prevTimes[0];
+      const newClose =
+        type === "close" ? time : prevTimes[prevTimes.length - 1];
+      return generateHoursArray({ open: newOpen, close: newClose });
+    });
+  };
+
+  useEffect(() => {
+    if (openingTimes.length === 0) {
+      setOpeningTimes(generateHoursArray({ open: "6:00", close: "22:00" }));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (openingTimes.length < 2) return;
+
+    const effectiveOpen = openingTimes[1];
+    const effectiveClose = openingTimes[openingTimes.length - 1];
+
+    let anyChange = false;
+    const updatedEntries = Array.from(dayShifts.entries()).map(
+      ([key, shift]) => {
+        const updatedShift = { ...shift };
+        if (updatedShift.startTime < effectiveOpen) {
+          updatedShift.startTime = effectiveOpen;
+          anyChange = true;
+        }
+        if (updatedShift.endTime > effectiveClose) {
+          updatedShift.endTime = effectiveClose;
+          anyChange = true;
+        }
+        return [key, updatedShift] as [string, Shift];
+      }
+    );
+
+    if (anyChange) {
+      const updatedDayShifts = new Map(updatedEntries);
+      updateShiftsToWeekDay(day, updatedDayShifts); // <- context call
+    }
+  }, [openingTimes]);
+
+  return {
+    openingTimes,
+    setOpeningTimes: handleOpeningTimeChange,
+  };
+}

--- a/src/ui/Rota/DayShiftEditShiftModal.tsx
+++ b/src/ui/Rota/DayShiftEditShiftModal.tsx
@@ -3,21 +3,21 @@ import Drag from "../Other/Drag";
 import { CandidateDropdown } from "./Modal/CadidateDropDown";
 import { ModalActions } from "./Modal/ModalActions";
 import { TimeInput } from "./Modal/TimeInput";
-import { Shift, Weekday } from "@/lib/rota/rota";
+import { Shift } from "@/lib/rota/rota";
 import { useEmployeeContext } from "@/lib/employees/context/EmployeeContext";
+import { useRotaContext } from "@/lib/rota/context/RotaContexts";
 
 type DayShiftEditShiftModalProps = {
   shift: Shift;
   onClose: () => void;
-  onSave: (day: Weekday, updatedShift: Shift) => void;
 };
 
 export default function DayShiftEditShiftModal({
   shift: initialShift,
   onClose,
-  onSave,
 }: DayShiftEditShiftModalProps) {
   const { employees } = useEmployeeContext();
+  const { updateShift } = useRotaContext();
   const [shift, setShift] = useState<Shift>(initialShift);
   const [selectedCandidate, setSelectedCandidate] = useState<string | null>(
     null
@@ -30,14 +30,15 @@ export default function DayShiftEditShiftModal({
         employee: selectedCandidate,
         candidates: [selectedCandidate],
       };
-      onSave(shift.day, updatedShift);
+      updateShift(shift.day, updatedShift);
     } else {
       const updatedShift = { ...shift };
       delete updatedShift.candidates;
       delete updatedShift.employee;
-      onSave(shift.day, updatedShift);
+
+      updateShift(shift.day, updatedShift);
     }
-  }, [shift, selectedCandidate, onSave]);
+  }, [shift, selectedCandidate, updateShift]);
 
   return (
     <Drag>

--- a/src/ui/Rota/DayShiftForm.tsx
+++ b/src/ui/Rota/DayShiftForm.tsx
@@ -1,18 +1,20 @@
-import { Shift, Weekday } from "@/lib/rota/rota";
+import { Weekday } from "@/lib/rota/rota";
+import { useRotaContext } from "@/lib/rota/context/RotaContexts";
 
 type DayShiftFormProps = {
   day: Weekday;
   openingTimes: string[];
-  addShift: (day: Weekday, shift: Shift) => void;
   isChecked: boolean;
 };
 
 export default function DayShiftForm({
   day,
   openingTimes,
-  addShift,
+
   isChecked,
 }: DayShiftFormProps) {
+  const { addShift } = useRotaContext();
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const startTime = (

--- a/src/ui/Rota/DayShiftShiftColumn.tsx
+++ b/src/ui/Rota/DayShiftShiftColumn.tsx
@@ -1,27 +1,23 @@
 import { Shift } from "@/lib/rota/rota";
 import { useEmployeeContext } from "@/lib/employees/context/EmployeeContext";
+import { useRotaContext } from "@/lib/rota/context/RotaContexts";
 
 type DayShiftShiftColumnProps = {
   shift: Shift;
-  colIndex: number;
   openingTimes: string[];
-  onShiftClick: (shift: Shift, shiftId: string) => void;
-  handleDeleteShift?: (shiftId: string) => void;
+  onShiftClick: (shift: Shift) => void;
 };
 
 export default function DayShiftShiftColumn({
   shift,
-  colIndex,
   openingTimes,
   onShiftClick,
-  handleDeleteShift,
 }: DayShiftShiftColumnProps) {
   const { employees } = useEmployeeContext();
-  const currentShiftId = shift.id ?? `col-${colIndex}`;
+  const { deleteShift } = useRotaContext();
   const assignedEmployee = shift.employee
     ? employees.find((emp) => emp.id === shift.employee)
     : null;
-  console.log("render shifts", { shift, assignedEmployee });
 
   return (
     <div
@@ -34,31 +30,29 @@ export default function DayShiftShiftColumn({
         if (time === shift.startTime) {
           return (
             <div
-              onClick={() => onShiftClick(shift, currentShiftId)}
-              key={`shift-${currentShiftId}-${rowIndex}`}
+              onClick={() => onShiftClick(shift)}
+              key={`shift-${shift.id}-${rowIndex}`}
               className={`cursor-pointer w-[33px] h-[33px] flex justify-center ${
                 assignedEmployee?.color ? assignedEmployee.color : "bg-gray-500"
               } border-b border-r border-gray-300 text-center relative`}
             >
-              {handleDeleteShift && (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDeleteShift(currentShiftId);
-                  }}
-                  className="absolute w-[28px] h-[28px] p-[1px] block -top-4 rounded-full bg-white border-2 border-red-400"
-                >
-                  <span className="flex justify-center">❌</span>
-                </button>
-              )}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  deleteShift(shift.day, shift.id!);
+                }}
+                className="absolute w-[28px] h-[28px] p-[1px] block -top-4 rounded-full bg-white border-2 border-red-400"
+              >
+                <span className="flex justify-center">❌</span>
+              </button>
             </div>
           );
         }
         if (time > shift.startTime && time <= shift.endTime) {
           return (
             <div
-              onClick={() => onShiftClick(shift, currentShiftId)}
-              key={`shift-${currentShiftId}-${rowIndex}`}
+              onClick={() => onShiftClick(shift)}
+              key={`shift-${shift.id!}-${rowIndex}`}
               className={`${
                 assignedEmployee ? assignedEmployee.color : "bg-gray-500"
               } h-[33px] w-[33px] flex  border-b border-r border-gray-300`}
@@ -67,7 +61,7 @@ export default function DayShiftShiftColumn({
         }
         return (
           <div
-            key={`empty-${currentShiftId}-${rowIndex}`}
+            key={`empty-${shift.id}-${rowIndex}`}
             className="h-[33px] w-[33px] border-b border-r border-gray-300"
           />
         );

--- a/src/ui/Rota/DayShifts.tsx
+++ b/src/ui/Rota/DayShifts.tsx
@@ -1,98 +1,32 @@
-import { Shift, Weekday, DayShiftsMap } from "@/lib/rota/rota";
+import { Weekday, DayShiftsMap } from "@/lib/rota/rota";
 import { Employee } from "@/lib/employees/employees";
-import { useState, useEffect } from "react";
-import { generateHoursArray, getDayhours } from "@/lib/rota/utils";
+import { useState } from "react";
+import { getDayhours } from "@/lib/rota/utils";
 import DayShiftsSummary from "./DayShiftSummary";
 import DayShiftForm from "./DayShiftForm";
 import DayShiftsGrid from "./DayShiftsGrid";
+import { useOpeningTimes } from "@/lib/rota/hooks/useOpeningTimes";
 
 type DayShiftsProps = {
   employees: Employee[];
   dayShifts: DayShiftsMap;
   day: Weekday;
-  assignShiftToWeekDay: (day: Weekday, shiftsForDay: DayShiftsMap) => void;
+  updateShiftsToWeekDay: (day: Weekday, shiftsForDay: DayShiftsMap) => void;
 };
 
 export default function DayShifts({
   day,
   dayShifts,
-  assignShiftToWeekDay,
+  updateShiftsToWeekDay,
 }: DayShiftsProps) {
   const [isChecked, setIsChecked] = useState(false);
-  const [openingTimes, setOpeningTimes] = useState<string[]>([]);
 
-  const handleOpeningTimeChange = (time: string, type: "open" | "close") => {
-    setOpeningTimes((prevTimes) => {
-      const newOpen = type === "open" ? time : prevTimes[0];
-      const newClose =
-        type === "close" ? time : prevTimes[prevTimes.length - 1];
-      const newTimes = generateHoursArray({ open: newOpen, close: newClose });
+  const { openingTimes, setOpeningTimes } = useOpeningTimes({ day, dayShifts });
 
-      return newTimes;
-    });
-  };
-
-  useEffect(() => {
-    const effectiveOpen = openingTimes[1];
-    const effectiveClose = openingTimes[openingTimes.length - 1];
-
-    let anyChange = false;
-    const updatedEntries = Array.from(dayShifts.entries()).map(
-      ([key, shift]) => {
-        const updatedShift = { ...shift };
-        if (updatedShift.startTime < effectiveOpen) {
-          updatedShift.startTime = effectiveOpen;
-          anyChange = true;
-        }
-        if (updatedShift.endTime > effectiveClose) {
-          updatedShift.endTime = effectiveClose;
-          anyChange = true;
-        }
-        return [key, updatedShift] as [string, Shift];
-      }
-    );
-
-    if (anyChange) {
-      const updatedDayShifts = new Map(updatedEntries);
-      assignShiftToWeekDay(day, updatedDayShifts);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [openingTimes]);
-
-  useEffect(() => {
-    if (openingTimes.length === 0)
-      setOpeningTimes(() =>
-        generateHoursArray({ open: "6:00", close: "22:00" })
-      );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const addShift = (day: Weekday, newShift: Shift) => {
-    const newId = newShift.id || `${newShift.startTime}-${newShift.endTime}`;
-
+  const handleDeleteShift = (shiftId: string) => {
     const updatedDayShifts = new Map(dayShifts);
-    updatedDayShifts.set(newId, newShift);
-
-    const sortedEntries = Array.from(updatedDayShifts.entries()).sort(
-      ([, a], [, b]) => a.startTime.localeCompare(b.startTime)
-    );
-    const sortedDayShifts = new Map(sortedEntries);
-    assignShiftToWeekDay(day, sortedDayShifts);
-  };
-
-  const updateShift = (day: Weekday, shiftToUpdate: Shift) => {
-    const newId =
-      shiftToUpdate.id || `${shiftToUpdate.startTime}-${shiftToUpdate.endTime}`;
-
-    const updatedDayShifts = new Map(dayShifts);
-    updatedDayShifts.delete(shiftToUpdate.id!);
-    updatedDayShifts.set(newId, shiftToUpdate);
-
-    const sortedEntries = Array.from(updatedDayShifts.entries()).sort(
-      ([, a], [, b]) => a.startTime.localeCompare(b.startTime)
-    );
-    const sortedDayShifts = new Map(sortedEntries);
-    assignShiftToWeekDay(day, sortedDayShifts);
+    updatedDayShifts.delete(shiftId);
+    updateShiftsToWeekDay(day, updatedDayShifts);
   };
 
   return (
@@ -100,7 +34,7 @@ export default function DayShifts({
       <DayShiftsSummary
         isChecked={isChecked}
         openingTimes={[openingTimes[1], openingTimes.at(-1)!]}
-        setOpeningTimes={handleOpeningTimeChange}
+        setOpeningTimes={setOpeningTimes}
         shiftCount={dayShifts.size}
         totalHours={getDayhours(Array.from(dayShifts.values()))}
         toggleChecked={setIsChecked}
@@ -109,12 +43,11 @@ export default function DayShifts({
         day={day}
         openingTimes={openingTimes}
         isChecked={isChecked}
-        addShift={addShift}
       />
       <DayShiftsGrid
         shifts={Array.from(dayShifts.values())}
         openingTimes={openingTimes}
-        updateShift={updateShift}
+        deleteShift={handleDeleteShift}
       />
     </div>
   );

--- a/src/ui/Rota/DayShiftsGrid.tsx
+++ b/src/ui/Rota/DayShiftsGrid.tsx
@@ -2,37 +2,29 @@ import React, { useState } from "react";
 import DayShiftTimeColumn from "./DayShiftTimeColumn";
 import DayShiftShiftColumn from "./DayShiftShiftColumn";
 import DayShiftEditShiftModal from "./DayShiftEditShiftModal";
-import { Shift, Weekday } from "@/lib/rota/rota";
+import { Shift } from "@/lib/rota/rota";
 
 type DayShiftsGridProps = {
   shifts: Shift[];
   openingTimes: string[];
-  handleDeleteShift?: (shiftId: string) => void;
-  updateShift: (day: Weekday, shift: Shift) => void;
+  deleteShift: (shiftId: string) => void;
 };
 
 export default function DayShiftsGrid({
   shifts,
   openingTimes,
-  handleDeleteShift,
-  updateShift,
 }: DayShiftsGridProps) {
   const [open, setOpen] = useState<boolean>(false);
   const [selectedShift, setSelectedShift] = useState<Shift | null>(null);
-  const [selectedShiftId, setSelectedShiftId] = useState<string | null>(null);
 
-  const handleShiftClick = (shift: Shift, shiftId: string) => {
+  const handleShiftClick = (shift: Shift) => {
     setOpen(true);
     setSelectedShift(shift);
-    setSelectedShiftId(shiftId);
   };
 
   const handleModalClose = () => {
     setOpen(false);
-  };
-
-  const handleModalSave = (day: Weekday, updatedShift: Shift) => {
-    updateShift(day, updatedShift);
+    setSelectedShift(null);
   };
 
   return (
@@ -43,21 +35,18 @@ export default function DayShiftsGrid({
       }}
     >
       <DayShiftTimeColumn openingTimes={openingTimes} />
-      {shifts.map((shiftItem, colIndex) => (
+      {shifts.map((shiftItem) => (
         <DayShiftShiftColumn
-          key={shiftItem.id ?? `col-${colIndex}`}
+          key={shiftItem.id}
           shift={shiftItem}
-          colIndex={colIndex}
           openingTimes={openingTimes}
           onShiftClick={handleShiftClick}
-          handleDeleteShift={handleDeleteShift}
         />
       ))}
       {open && selectedShift && (
         <DayShiftEditShiftModal
           shift={selectedShift}
           onClose={handleModalClose}
-          onSave={handleModalSave}
         />
       )}
     </div>

--- a/src/ui/Rota/Modal/CadidateDropDown.tsx
+++ b/src/ui/Rota/Modal/CadidateDropDown.tsx
@@ -1,9 +1,10 @@
 import { Employee } from "@/lib/employees/employees";
 import { Shift } from "@/lib/rota/rota";
+import { isEmployeeAvailableForShift } from "@/lib/rota/utils";
 import { useState } from "react";
 
 type CandidateDropdownProps = {
-  employees: Employee[]; // Adjust the type based on your employee model
+  employees: Employee[];
   selectedCandidate: string | null;
   shift: Shift;
   onSelectCandidate: (candidate: string | null) => void;

--- a/src/ui/Rota/WeeklyRota.tsx
+++ b/src/ui/Rota/WeeklyRota.tsx
@@ -1,11 +1,9 @@
 "use client";
-
-import { Week, DayShiftsMap, Weekday } from "@/lib/rota/rota";
-import { WEEKDAYS, INITIAL_WEEK } from "@/lib/rota/constants";
+import { WEEKDAYS } from "@/lib/rota/constants";
 import DayTitle from "./DayTitle";
 import DayShifts from "./DayShifts";
 import { Employee } from "@/lib/employees/employees";
-import React, { useState, useCallback } from "react";
+import { useRotaContext } from "@/lib/rota/context/RotaContexts";
 
 interface WeeklyRotaProps {
   employees: Employee[];
@@ -13,22 +11,7 @@ interface WeeklyRotaProps {
 }
 
 function WeeklyRota({ employees, title }: WeeklyRotaProps) {
-  const [shifts, setShifts] = useState<Week>(INITIAL_WEEK);
-  const [assignmentStatus, setAssignmentStatus] = useState<
-    "modified" | "saved"
-  >("saved");
-
-  const assignShiftToWeekDay = useCallback(
-    (day: Weekday, dayShifts: DayShiftsMap) => {
-      setShifts((prevShifts) => {
-        const updatedShifts = new Map(prevShifts);
-        updatedShifts.set(day, dayShifts);
-        return updatedShifts;
-      });
-      setAssignmentStatus("modified");
-    },
-    []
-  );
+  const { shifts, updateShiftsToWeekDay } = useRotaContext();
 
   return (
     <div>
@@ -46,7 +29,7 @@ function WeeklyRota({ employees, title }: WeeklyRotaProps) {
                 day={weekDay}
                 employees={employees}
                 dayShifts={dayShifts}
-                assignShiftToWeekDay={assignShiftToWeekDay}
+                updateShiftsToWeekDay={updateShiftsToWeekDay}
               />
             </div>
           );


### PR DESCRIPTION
### 📋 Summary

This PR introduces a refactor to manage rota (shift) state globally using a new `RotaContext`. This reduces prop-drilling, improves maintainability, and paves the way for cleaner UI logic and better scalability.

* * *

### ✨ What's Changed

#### 🧠 State Management

*   Introduced `RotaContext` for centralized shift state:
    
    *   `addShift(day, shift)`
        
    *   `updateShift(day, shift)`
        
    *   `deleteShift(day, shiftId)`
        
    *   `updateShiftsToWeekDay(day, dayShifts)`
        
*   Wrapped `` with `` in `RootLayout`.
    

#### 🔄 Component Refactors

*   **`WeeklyRota`** now reads from context instead of local `useState`.
    
*   **`DayShifts`** uses `useOpeningTimes` hook and no longer handles local shift state.
    
*   **`DayShiftsGrid`** simplified: no longer handles shift deletion internally.
    
*   **`DayShiftShiftColumn`** now deletes directly via `RotaContext`.
    
*   **`DayShiftForm`** adds shifts using context's `addShift`.
    
*   **`DayShiftEditShiftModal`** uses context’s `updateShift` method.
    
*   **`CandidateDropdown`** updated to use utility function for availability logic.
    

#### 🪝 New Custom Hook

*   **`useOpeningTimes`**
    
    *   Generates and manages valid opening/closing times.
        
    *   Auto-trims shifts outside business hours and syncs with global context.
        

* * *